### PR TITLE
Query trigger resolves on stream close

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,12 +2,10 @@ export type PrimitiveParam = string | boolean | number;
 
 export interface UseReadableHookData {
   value: string;
-  done: boolean;
   isStreaming: boolean;
 }
 
 export const DEFAULT_STREAM_DATA: UseReadableHookData = {
   value: '',
-  done: false,
   isStreaming: false,
 };


### PR DESCRIPTION
update API so the useReadable query trigger resolves when the stream closes instead of resolving immediately